### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<cglib.version>3.1</cglib.version>
 		<javassit.version>3.19.0-GA</javassit.version>
 		<commons.lang3.version>3.4</commons.lang3.version>
-		<commons.collection.version>3.2.1</commons.collection.version>
+		<commons.collection.version>3.2.2</commons.collection.version>
 		<commons.codec.version>1.10</commons.codec.version>
 		<guava.version>18.0</guava.version>
 		<fastjson.version>1.1.15</fastjson.version>


### PR DESCRIPTION

Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/